### PR TITLE
Add default automatic setup function in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ require ('mason-null-ls').setup({
 require 'mason-null-ls'.setup_handlers {
     function(source_name, methods)
       -- all sources with no handler get passed here
+      require("mason-null-ls.automatic_setup")(source_name, methods)
     end,
     stylua = function(source_name, methods)
       null_ls.register(null_ls.builtins.formatting.stylua)

--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ require ('mason-null-ls').setup({
 require 'mason-null-ls'.setup_handlers {
     function(source_name, methods)
       -- all sources with no handler get passed here
+
+      -- To keep the original functionality of `automatic_setup = true`,
+      -- please add the below.
       require("mason-null-ls.automatic_setup")(source_name, methods)
     end,
     stylua = function(source_name, methods)


### PR DESCRIPTION
Adding a default function to the example automatic setup so that any installed
null-ls formatters etc will be auto-installed even if you don't have a specific
setup for them

Resolves #41  
~Didn't need the `if methods[1]` when using `vim.tbl_map`~

~You have a function that's basically the same in automatic_setup.lua. I'm not
sure if this is supposed to run as the default function but I couldn't get it to
do so~  
Found what the function should be based on what you have in `mason-nvim-dap`