### PR TITLE
feat: add ocamlformat

### DIFF
--- a/lua/mason-null-ls/mappings/filetype.lua
+++ b/lua/mason-null-ls/mappings/filetype.lua
@@ -333,6 +333,10 @@ return {
         --   "nixfmt",
         --   "nixpkgs_fmt",
         -- },
+        ocaml = {
+                formatting = { "ocamlformat" }
+        },
+
         org = {
                 "cbfmt",
         },


### PR DESCRIPTION
mason.nvim added support for ocamlformat in [this PR](https://github.com/williamboman/mason.nvim/pull/851).