### PR TITLE
feat: add latexindent

### DIFF
--- a/lua/mason-null-ls/mappings/filetype.lua
+++ b/lua/mason-null-ls/mappings/filetype.lua
@@ -491,9 +491,9 @@ return {
         -- },
         tex = {
                 --   "chktex",
+                "latexindent",
                 "proselint",
                 "vale",
-                --   "latexindent",
         },
         -- text = {
         --   "dictionary",


### PR DESCRIPTION
mason.nvim added support for latexindent in [this PR](https://github.com/williamboman/mason.nvim/pull/949).