### PR TITLE
feat!: removing `setup_handlers` function. automatic_setup is now implicitly true.

### DIFF
--- a/lua/mason-null-ls/init.lua
+++ b/lua/mason-null-ls/init.lua
@@ -6,13 +6,8 @@ local M = {}
 -- Currently this only needs to be evaluated for the same list passed in.
 -- @param source string
 -- @param types string[]
-local default_setup = function(source, types)
-	local settings = require('mason-null-ls.settings')
-	if settings.current.automatic_setup then
-		local user_types = settings.current.automatic_setup.types or {}
-		local user_source_types = user_types[source]
-		require('mason-null-ls.automatic_setup')(source, user_source_types or types)
-	end
+M.default_setup = function(source, types)
+	require('mason-null-ls.automatic_setup')(source, types)
 end
 
 ---@param handlers table<string, fun(source_name: string, methods: string[])> | nil
@@ -25,7 +20,7 @@ local function setup_handlers(handlers)
 	local registry = require('mason-registry')
 	local notify = require('mason-core.notify')
 
-	local default_handler = Optional.of_nilable(handlers[1]):or_(_.always(Optional.of_nilable(default_setup)))
+	local default_handler = Optional.of_nilable(handlers[1]):or_(_.always(Optional.of_nilable(M.default_setup)))
 
 	_.each(function(handler)
 		if type(handler) == 'string' and not source_mappings.getPackageFromNullLs(handler) then
@@ -104,13 +99,6 @@ function M.setup(config)
 	end
 
 	require('mason-null-ls.api.command')
-end
-
----@param handlers table<string, fun(source_name: string, methods: string[])> | nil
----@deprecated
----@return nil
-function M.setup_handlers(handlers)
-	return setup_handlers(handlers)
 end
 
 ---@return string[]

--- a/lua/mason-null-ls/settings.lua
+++ b/lua/mason-null-ls/settings.lua
@@ -2,7 +2,6 @@ local M = {}
 
 ---@class MasonNullLsSettings
 ---@field handlers table | nil
----@field automatic_setup boolean | table
 ---@field ensure_installed table
 ---@field automatic_installation boolean | table
 local DEFAULT_SETTINGS = {
@@ -18,14 +17,6 @@ local DEFAULT_SETTINGS = {
 	--   - { exclude: string[] }: All servers set up via mason-null-ls, except the ones provided in the list, are automatically installed.
 	--       Example: automatic_installation = { exclude = { "stylua", "eslint", } }
 	automatic_installation = false,
-	-- Whether sources that are installed in mason should be automatically set up in null-ls.
-	-- Removes the need to set up null-ls manually.
-	-- Can either be:
-	-- 	- false: Null-ls is not automatically registered.
-	-- 	- true: Null-ls is automatically registered.
-	-- 	- { types = { SOURCE_NAME = {TYPES} } }. Allows overriding default configuration.
-	-- 	Ex: { types = { eslint_d = {'formatting'} } }
-	automatic_setup = false,
 	handlers = nil,
 }
 
@@ -34,15 +25,10 @@ M.current = M._DEFAULT_SETTINGS
 
 ---@param opts MasonNullLsSettings
 function M.set(opts)
-	if opts.automatic_setup == true then
-		opts.automatic_setup = {}
-	end
-
 	M.current = vim.tbl_deep_extend('force', M.current, opts)
 	vim.validate({
 		ensure_installed = { M.current.ensure_installed, 'table', true },
 		automatic_installation = { M.current.automatic_installation, { 'boolean', 'table' }, true },
-		automatic_setup = { M.current.automatic_setup, { 'boolean', 'table' }, true },
 		handlers = { M.current.handlers, { 'table' }, true },
 	})
 end


### PR DESCRIPTION
Migration Guide:

1. Move `setup_handlers` table to `setup({handlers = TABLE})`.
2. To disable `automatic_setup`, provide an empty function to `handlers` like `handlers = {function() end,}`