### PR TITLE
fix: enable default_setup during reload

### DIFF
--- a/lua/mason-null-ls/automatic_setup.lua
+++ b/lua/mason-null-ls/automatic_setup.lua
@@ -1,12 +1,11 @@
-local _ = require('mason-core.functional')
 local null_ls = require('null-ls')
 
 -- @param source string
 -- @param types string[]
-return _.memoize(function(source, types)
+return function(source, types)
 	if not null_ls.is_registered(source) then
 		vim.tbl_map(function(type)
 			null_ls.register(null_ls.builtins[type][source])
 		end, types)
 	end
-end)
+end

--- a/lua/mason-null-ls/init.lua
+++ b/lua/mason-null-ls/init.lua
@@ -6,9 +6,7 @@ local M = {}
 -- Currently this only needs to be evaluated for the same list passed in.
 -- @param source string
 -- @param types string[]
-M.default_setup = function(source, types)
-	require('mason-null-ls.automatic_setup')(source, types)
-end
+M.default_setup = require('mason-null-ls.automatic_setup')
 
 ---@param handlers table<string, fun(source_name: string, methods: string[])> | nil
 ---@return nil


### PR DESCRIPTION
The `mason-null-ls.automatic_setup` function has no return value and so can't be memoized effectively -- it exists strictly for its side-effects. This change is necessary to make mason-null-ls cooperate during a reload of configuration.

Previously the below code would work on initial executtion but noop subsequently, resulting in no null-ls diagnostics. Now it behaves as expected.

```lua
require("null-ls.config").reset()
require("null-ls").setup({ on_attach = M.on_attach_null_ls })
require("mason-null-ls").setup({
  handlers = { require("mason-null-ls").default_setup },
})
```

Without this change I have to work around, using an un-memoized copy-paste of the automatic-setup function as my handler.