### PR TITLE
feat: always setup handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,7 @@ setup for null-ls.
 
 ```lua
 require("mason").setup()
-require("mason-null-ls").setup({
-    automatic_setup = true,
-})
+require("mason-null-ls").setup()
 ```
 
 See the Default Configuration section to understand how the default dap configs

--- a/lua/mason-null-ls/init.lua
+++ b/lua/mason-null-ls/init.lua
@@ -92,9 +92,7 @@ function M.setup(config)
 		require('mason-null-ls.automatic_installation')()
 	end
 
-	if settings.current.handlers then
-		setup_handlers(settings.current.handlers)
-	end
+	setup_handlers(settings.current.handlers)
 
 	require('mason-null-ls.api.command')
 end


### PR DESCRIPTION
    Previously, the suggested config didn't cause any null-ls sources to be
    configured as intended. Technically this is a fix, but it may break a couple
    users by restoring the intended behavior.

    also:

      Updated doc to remove the remaining reference to `automatic_setup`, since
      it has no effect.
