### PR TITLE
feat: add `ignore_methods` to ignore setup of null-ls source method types

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ local DEFAULT_SETTINGS = {
     -- A list of sources to install if they're not already installed.
     -- This setting has no relation with the `automatic_installation` setting.
     ensure_installed = {},
+    -- A list of null-ls methods to ignore when calling handlers.
+    -- This setting is useful if some functionality is handled by other plugins such as `conform` and `nvim-lint`
+    ignore_methods = {},
     -- Run `require("null-ls").setup`.
     -- Will automatically install masons tools based on selected sources in `null-ls`.
     -- Can also be an exclusion list.

--- a/lua/mason-null-ls/init.lua
+++ b/lua/mason-null-ls/init.lua
@@ -40,7 +40,11 @@ local function setup_handlers(handlers)
 		Optional.of_nilable(handlers[source_name]):or_(_.always(default_handler)):if_present(function(handler)
 			log.fmt_trace('Calling handler for %s', source_name)
 
+			local ignored_methods = require('mason-null-ls.settings').current.ignore_methods
 			local types = _.filter_map(function(method)
+				if vim.tbl_contains(ignored_methods, method) then
+					return Optional.empty()
+				end
 				local ok, _ = pcall(require, string.format('null-ls.builtins.%s.%s', method, source_name))
 				if ok then
 					return Optional.of(method)

--- a/lua/mason-null-ls/settings.lua
+++ b/lua/mason-null-ls/settings.lua
@@ -2,12 +2,16 @@ local M = {}
 
 ---@class MasonNullLsSettings
 ---@field handlers table | nil
+---@field ignore_methods table
 ---@field ensure_installed table
 ---@field automatic_installation boolean | table
 local DEFAULT_SETTINGS = {
 	-- A list of sources to automatically install if they're not already installed. Example: { "stylua" }
 	-- This setting has no relation with the `automatic_installation` setting.
 	ensure_installed = {},
+	-- A list of null-ls methods to ignore when calling handlers.
+	-- This setting is useful if some functionality is handled by other plugins such as `conform` and `nvim-lint`
+	ignore_methods = {},
 	-- NOTE: this is left here for future porting in case needed
 	-- Whether sources that are set up (via null-ls) should be automatically installed if they're not already installed.
 	-- This setting has no relation with the `ensure_installed` setting.
@@ -28,6 +32,7 @@ function M.set(opts)
 	M.current = vim.tbl_deep_extend('force', M.current, opts)
 	vim.validate({
 		ensure_installed = { M.current.ensure_installed, 'table', true },
+		ignore_methods = { M.current.ignore_methods, 'table', true },
 		automatic_installation = { M.current.automatic_installation, { 'boolean', 'table' }, true },
 		handlers = { M.current.handlers, { 'table' }, true },
 	})


### PR DESCRIPTION
A lot more people nowadays are starting to use more tools like `conform` or `nvim-lint` and things which replace certain functionality in null-ls but not all of it. It might be a good idea to add the ability to ignore types by default. Like if I'm using `conform` and still want to rely on `mason-null-ls` for diagnostics and code actions, I could add to the setup like `ignore_methods = { "formatting" }` since that's handled by `conform`. Or if I use both `conform` and `nvim-lint` but want to use `null-ls` for code actions, adding `ignore_methods = { "formatting", "diagnostics" }` which won't add those types to the handlers when they are called.

*Update*: originally called `ignore_types`, `ignore_methods` aligns better with the terminology used here and in `null-ls`/`none-ls`.