### PR TITLE
feat: add `methods` to enable or disable specific null-ls source method types

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,15 @@ local DEFAULT_SETTINGS = {
     -- A list of sources to install if they're not already installed.
     -- This setting has no relation with the `automatic_installation` setting.
     ensure_installed = {},
+    -- Enable or disable null-ls methods to get set up
+    -- This setting is useful if some functionality is handled by other plugins such as `conform` and `nvim-lint`
+    methods = {
+        diagnostics = true,
+        formatting = true,
+        code_actions = true,
+        completion = true,
+        hover = true,
+    },
     -- Run `require("null-ls").setup`.
     -- Will automatically install masons tools based on selected sources in `null-ls`.
     -- Can also be an exclusion list.

--- a/lua/mason-null-ls/init.lua
+++ b/lua/mason-null-ls/init.lua
@@ -20,6 +20,13 @@ local function setup_handlers(handlers)
 
 	local default_handler = Optional.of_nilable(handlers[1]):or_(_.always(Optional.of_nilable(M.default_setup)))
 
+	local methods = {}
+	for method, enabled in pairs(require('mason-null-ls.settings').current.methods) do
+		if enabled then
+			table.insert(methods, method)
+		end
+	end
+
 	_.each(function(handler)
 		if type(handler) == 'string' and not source_mappings.getPackageFromNullLs(handler) then
 			notify(
@@ -47,7 +54,7 @@ local function setup_handlers(handlers)
 				else
 					return Optional.empty()
 				end
-			end, { 'diagnostics', 'formatting', 'code_actions', 'completion', 'hover' })
+			end, methods)
 
 			local ok, err = pcall(handler, source_name, types)
 

--- a/lua/mason-null-ls/settings.lua
+++ b/lua/mason-null-ls/settings.lua
@@ -1,13 +1,30 @@
 local M = {}
 
+---@class MasonNullLsMethods
+---@field diagnostics boolean
+---@field formatting boolean
+---@field code_actions boolean
+---@field completion boolean
+---@field hover boolean
+
 ---@class MasonNullLsSettings
 ---@field handlers table | nil
+---@field ignore_methods MasonNullLsMethods
 ---@field ensure_installed table
 ---@field automatic_installation boolean | table
 local DEFAULT_SETTINGS = {
 	-- A list of sources to automatically install if they're not already installed. Example: { "stylua" }
 	-- This setting has no relation with the `automatic_installation` setting.
 	ensure_installed = {},
+	-- A list of null-ls methods to ignore when calling handlers.
+	-- This setting is useful if some functionality is handled by other plugins such as `conform` and `nvim-lint`
+	methods = {
+		diagnostics = true,
+		formatting = true,
+		code_actions = true,
+		completion = true,
+		hover = true,
+	},
 	-- NOTE: this is left here for future porting in case needed
 	-- Whether sources that are set up (via null-ls) should be automatically installed if they're not already installed.
 	-- This setting has no relation with the `ensure_installed` setting.
@@ -28,6 +45,7 @@ function M.set(opts)
 	M.current = vim.tbl_deep_extend('force', M.current, opts)
 	vim.validate({
 		ensure_installed = { M.current.ensure_installed, 'table', true },
+		methods = { M.current.methods, 'table', true },
 		automatic_installation = { M.current.automatic_installation, { 'boolean', 'table' }, true },
 		handlers = { M.current.handlers, { 'table' }, true },
 	})


### PR DESCRIPTION
This potentially supersedes #93 . It takes a slightly different approach to make it easier to modify individual methods. Let me know what you think! I did some performance testing and it doesn't seem to make any significant impact even with a ton of packages getting setup.

This approach also provides nice completion when using the types in the lua language server