### PR TITLE
fix(docs): config requires `ignore_methods` field

### DIFF
--- a/lua/mason-null-ls/settings.lua
+++ b/lua/mason-null-ls/settings.lua
@@ -9,7 +9,7 @@ local M = {}
 
 ---@class MasonNullLsSettings
 ---@field handlers table | nil
----@field methods MasonNullLsMethods
+---@field methods MasonNullLsMethods | nil
 ---@field ensure_installed table
 ---@field automatic_installation boolean | table
 local DEFAULT_SETTINGS = {

--- a/lua/mason-null-ls/settings.lua
+++ b/lua/mason-null-ls/settings.lua
@@ -9,7 +9,7 @@ local M = {}
 
 ---@class MasonNullLsSettings
 ---@field handlers table | nil
----@field ignore_methods MasonNullLsMethods
+---@field methods MasonNullLsMethods
 ---@field ensure_installed table
 ---@field automatic_installation boolean | table
 local DEFAULT_SETTINGS = {


### PR DESCRIPTION
A typo in the field annotations is requiring an incorrect field. I am also guessing that the field is optional as it looks like it's only useful when handlers are defined.