### PR TITLE
feat: add cmake_lint mapping

### DIFF
--- a/lua/mason-null-ls/mappings/source.lua
+++ b/lua/mason-null-ls/mappings/source.lua
@@ -5,6 +5,7 @@ local M = {}
 
 ---Maps null_ls source name to its corresponding package name.
 local null_ls_to_package = {
+	['cmake_lint'] = 'cmakelint',
 	['cmake_format'] = 'cmakelang',
 	['eslint_d'] = 'eslint_d',
 	['goimports_reviser'] = 'goimports_reviser',


### PR DESCRIPTION
none-ls uses `cmake_lint` as a name but Mason uses `cmakelint`, this causes the plugin to not automatically download the package.

none-ls: https://github.com/nvimtools/none-ls.nvim/blob/main/doc/BUILTINS.md#cmake_lint
mason: https://github.com/mason-org/mason-registry/blob/main/packages/cmakelint/package.yaml#L2