### PR TITLE
chore: add `ensure_installed` error log

### DIFF
--- a/lua/mason-null-ls/ensure_installed.lua
+++ b/lua/mason-null-ls/ensure_installed.lua
@@ -35,6 +35,13 @@ local function ensure_installed()
 						vim.schedule_wrap(function()
 							if pkg:is_installed() then
 								vim.notify(('[mason-null-ls] %s was installed'):format(pkg.name))
+							else
+								vim.notify(
+									('[mason-null-ls] failed to install %s. Installation logs are available in :Mason and :MasonLog'):format(
+										pkg.name
+									),
+									vim.log.levels.ERROR
+								)
 							end
 						end)
 					)


### PR DESCRIPTION
legit just copy and pasted what williamboman did [here](https://github.com/williamboman/mason-lspconfig.nvim/blob/44509689b9bf3984d729cc264aacb31cb7f41668/lua/mason-lspconfig/install.lua#L19-L22) in his solution.

i tried to see if i could extract the exact log which affected the installation, however that would add way too much complexity for no reason whatsoever (i can do it if you want me to).

dont blame me for the ugly formatting, stylua is at fault for that.

at least it fulfils the purpose which is wanted and closes #103 