### PR TITLE
fix: Update vim.validate calls to the new syntax

### DIFF
--- a/lua/mason-null-ls/settings.lua
+++ b/lua/mason-null-ls/settings.lua
@@ -43,12 +43,10 @@ M.current = M._DEFAULT_SETTINGS
 ---@param opts MasonNullLsSettings
 function M.set(opts)
 	M.current = vim.tbl_deep_extend('force', M.current, opts)
-	vim.validate({
-		ensure_installed = { M.current.ensure_installed, 'table', true },
-		methods = { M.current.methods, 'table', true },
-		automatic_installation = { M.current.automatic_installation, { 'boolean', 'table' }, true },
-		handlers = { M.current.handlers, { 'table' }, true },
-	})
+	vim.validate('ensure_installed', M.current.ensure_installed, 'table', true)
+	vim.validate('methods', M.current.methods, 'table', true)
+	vim.validate('automatic_installation', M.current.automatic_installation, {'boolean', 'table'}, true)
+	vim.validate('handlers', M.current.handlers, 'table', true)
 end
 
 return M


### PR DESCRIPTION
In nvim 0.11, the current call to vim.validate() has been deprecated. From the healthcheck:
```
==============================================================================
vim.deprecated:                       require("vim.deprecated.health").check()

 ~
- ⚠️ WARNING vim.validate is deprecated. Feature will be removed in Nvim 1.0
  - ADVICE:
    - use vim.validate(name, value, validator, optional_or_msg) instead.
    - stack traceback:
        /Users/mikemi/.local/share/nvim/lazy/mason-null-ls.nvim/lua/mason-null-ls/settings.lua:46
        /Users/mikemi/.local/share/nvim/lazy/mason-null-ls.nvim/lua/mason-null-ls/init.lua:82
        /Users/mikemi/dotfiles/config/nvim/init.lua:496
        /Users/mikemi/.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:380
        [C]:-1
        /Users/mikemi/.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/util.lua:135
        /Users/mikemi/.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:395
        /Users/mikemi/.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:362
        /Users/mikemi/.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:197
        /Users/mikemi/.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:127
        /Users/mikemi/.local/share/nvim/lazy/lazy.nvim/lua/lazy/init.lua:112
        /Users/mikemi/dotfiles/config/nvim/init.lua:30

```